### PR TITLE
removing elements of requests

### DIFF
--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -275,6 +275,7 @@ class Monitor implements Runnable, IExtensionStateListener {
         if (lock.tryLock()) {
             try {
                 // stdout.println("getDNSQuerys");
+                long time = System.currentTimeMillis();
                 List<String> dnsQuerys = getDNSQuerys();
                 for (String query : dnsQuerys) {
                     
@@ -301,7 +302,7 @@ class Monitor implements Runnable, IExtensionStateListener {
                 //removing payloads 
                 for (int i=0; i<this.requestsPayloads.size(); i++) {
                     long age = (long) requestsPayloads.get(i)[2];
-                    if ((System.currentTimeMillis() - age) > aliveTime) {
+                    if ((time - age) > aliveTime) {
                         requestsPayloads.remove(i);
                         i--;
                     }


### PR DESCRIPTION
Reviewing the code I noticed that there were 2 HashMap (payloads, requests) in the Monitor class that were filled but not emptied. Fix it and now its elements are removed after a few seconds.